### PR TITLE
lab02: Add URL to verify MinIO buckets

### DIFF
--- a/fh-local-labs/lab-02/README.md
+++ b/fh-local-labs/lab-02/README.md
@@ -144,7 +144,7 @@ curl -s -H "$AUTH_HEADER" http://localhost:4000/connect/v1/apache/$CONNECT_ID/co
 
 1. Check Topic Data
 
-Once the source connector is running, it begins producing messages. The sink connector, when started, consumes messages from the `orders` topic and writes them to the MinIO bucket (`fh-dev-bucket`). Records are stored in the path: `topics/orders/partition=<num>` within the bucket.
+Once the source connector is running, it begins producing messages. The sink connector, when started, consumes messages from the `orders` topic and writes them to the MinIO bucket (`fh-dev-bucket`), viewable at http://localhost:9001/. Records are stored in the path: `topics/orders/partition=<num>` within the bucket.
 
 ![](./images/connect-api-01.png)
 


### PR DESCRIPTION
One may still need to look up the username and password in the config files, but this is a better starting point